### PR TITLE
Change pandas version number

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==0.56.0
-pandas==0.1.0
+pandas==1.0.0
 plotly==4.5.0
 numpy==1.18.1


### PR DESCRIPTION
Hey 👋,

spotted this repository because it is being launched on mybinder.org at a very high rate (from an IP address at the National Institutes of Health). I think the pandas version number was meant to be 1.0.0 and not 0.1.0. This PR changes it and should allow the repo to be built on mybinder.org.

Right now the launch requests aren't hurting anyone. If the launch requests continue and start effecting other users we will temporarily ban this repository. If we do that I will post an issue on this repo to let you know and how to get in touch to get it enabled again.